### PR TITLE
This fixes problem of linking dabc_shell against ncurses due to missin…

### DIFF
--- a/applications/ncurses/CMakeLists.txt
+++ b/applications/ncurses/CMakeLists.txt
@@ -3,16 +3,10 @@ project(dabc-ncurses)
 find_package(DABC)
 include(${DABC_USE_FILE})
 
-find_library(NCURSES_LIBRARY ncurses)
-find_library(MENU_LIBRARY menu)
+find_package(PkgConfig REQUIRED)
+pkg_check_modules(ncurses REQUIRED ncurses menu IMPORTED_TARGET)
 
-find_path(NCURSES_INCLUDE_DIR ncurses.h /usr/include/ncurses)
-find_path(MENU_INCLUDE_DIR menu.h /usr/include/ncurses)
-
-if(NCURSES_LIBRARY AND MENU_LIBRARY AND NCURSES_INCLUDE_DIR AND MENU_INCLUDE_DIR)
-   DABC_EXECUTABLE(dabc_shell
-                   SOURCES dabc_shell.cxx
-                   LIBRARIES ${DabcBase_LIBRARY} ${NCURSES_LIBRARY} ${MENU_LIBRARY}
-                   INCLUDES ${NCURSES_INCLUDE_DIR} ${MENU_INCLUDE_DIR}
-                   CHECKSTD)
-endif()
+DABC_EXECUTABLE(dabc_shell
+                SOURCES dabc_shell.cxx
+                LIBRARIES ${DabcBase_LIBRARY} PkgConfig::ncurses
+                CHECKSTD)

--- a/applications/ncurses/CMakeLists.txt
+++ b/applications/ncurses/CMakeLists.txt
@@ -3,10 +3,14 @@ project(dabc-ncurses)
 find_package(DABC)
 include(${DABC_USE_FILE})
 
-find_package(PkgConfig REQUIRED)
-pkg_check_modules(ncurses REQUIRED ncurses menu IMPORTED_TARGET)
+find_package(PkgConfig)
+if (PkgConfig_FOUND)
+    pkg_check_modules(ncurses ncurses menu IMPORTED_TARGET)
 
-DABC_EXECUTABLE(dabc_shell
-                SOURCES dabc_shell.cxx
-                LIBRARIES ${DabcBase_LIBRARY} PkgConfig::ncurses
-                CHECKSTD)
+    if (ncurses_FOUND)
+        DABC_EXECUTABLE(dabc_shell
+                        SOURCES dabc_shell.cxx
+                        LIBRARIES ${DabcBase_LIBRARY} PkgConfig::ncurses
+                        CHECKSTD)
+    endif()
+endif()


### PR DESCRIPTION
…g tinfo library.

Error reported to slinev in private communication. This fix also uses modern aproach of using pkgconfig which is supplied with ncurses and provides accurate way of obtaing includes and libs.