### PR TITLE
Introduce new dogma format

### DIFF
--- a/plugins/dogma/dldprint.cxx
+++ b/plugins/dogma/dldprint.cxx
@@ -22,12 +22,13 @@
 
 #include "dogma/api.h"
 #include "dogma/tdc5.h"
+#include "dogma/ur-unpacker.h"
 #include "dabc/Url.h"
 #include "dabc/api.h"
 
 #include "../hadaq/tdc_print_code.cxx"
 
-
+#include <unordered_map>
 
 int usage(const char *errstr = nullptr)
 {
@@ -96,6 +97,16 @@ std::map<uint32_t, TuStat> tu_stats;
 uint32_t ref_addr = 0;
 
 
+std::unordered_map<int, ur_config> cfgs = {{2051,
+   {
+    .coarsetime_len = 18,
+    .finetime_len = 11,
+    .tdc_type = 3,
+    .freq = 150,
+    .has_edge_type = true
+  }}};
+
+
 void print_tu(dogma::DogmaTu *tu, const char *prefix = "")
 {
    if (!onlytdc || (onlytdc == tu->GetAddr())) {
@@ -115,12 +126,16 @@ void print_tu(dogma::DogmaTu *tu, const char *prefix = "")
       }
    } else if (is_tdc(tu->GetAddr()) || (onlytdc && (onlytdc == tu->GetAddr()))) {
       // this is new TDC5
-      tdc5_header h;
-      tdc5_parse_it it;
-      tdc5_time tm;
+
+      ur_context it;
+      ur_header h;
+      ur_time tm;
       const char *buf = (const char *) tu->RawHeader();
       int pktlen = tu->GetRawPacketSize();
-      tdc5_parse_header(&h, &it, buf, pktlen);
+
+      ur_set_config(&it, &cfgs[2051]);
+
+      ur_parse_header(&h, &it, buf, pktlen);
 
       double last_rising_tm = 0.;
       int last_rising_ch = -1;
@@ -129,7 +144,7 @@ void print_tu(dogma::DogmaTu *tu, const char *prefix = "")
       // keep for debug purposes
       // if (h.trig_time != tu->GetTdc5TrigTime())
       //   printf("%s   DECODING TRIGGER TIME FAILURE 0x%016lx 0x%016lx\n", prefix, (long unsigned) h.trig_time, (long unsigned) tu->GetTdc5TrigTime());
-      while (tdc5_parse_next(&tm, &it, buf, pktlen) == 1) {
+      while (ur_parse_next(&tm, &it, buf, pktlen) == 1) {
          unsigned fine = tm.fine;
          if (fine < fine_min5)
             fine = fine_min5;

--- a/plugins/dogma/dldprint.cxx
+++ b/plugins/dogma/dldprint.cxx
@@ -133,7 +133,15 @@ void print_tu(dogma::DogmaTu *tu, const char *prefix = "")
       const char *buf = (const char *) tu->RawHeader();
       int pktlen = tu->GetRawPacketSize();
 
-      ur_set_config(&it, &cfgs[2051]);
+      ur_config cfg_2051 = {
+         .coarsetime_len = 18,
+         .finetime_len = 11,
+         .tdc_type = 3,
+         .freq = 150,
+         .has_edge_type = true
+      };
+
+      ur_set_config(&it, &cfg_2051);
 
       ur_parse_header(&h, &it, buf, pktlen);
 

--- a/plugins/dogma/dldprint.cxx
+++ b/plugins/dogma/dldprint.cxx
@@ -96,15 +96,20 @@ bool is_tdc(unsigned id)
 std::map<uint32_t, TuStat> tu_stats;
 uint32_t ref_addr = 0;
 
-ur_config cfg_2051 = {
-   .coarsetime_len = 18,
-   .finetime_len = 11,
-   .tdc_type = 3,
-   .freq = 150,
-   .has_edge_type = true
-};
+ur_config cfg_2051;
 
-std::unordered_map<int, ur_config> cfgs = {{2051, cfg_2051}};
+std::unordered_map<int, ur_config> cfgs;
+
+void _init_ur_config()
+{
+   cfg_2051.coarsetime_len = 18;
+   cfg_2051.finetime_len = 11;
+   cfg_2051.tdc_type = 3;
+   cfg_2051.freq = 150;
+   cfg_2051.has_edge_type = true;
+
+   cfgs[2051] = cfg_2051;
+}
 
 
 void print_tu(dogma::DogmaTu *tu, const char *prefix = "")
@@ -114,7 +119,7 @@ void print_tu(dogma::DogmaTu *tu, const char *prefix = "")
       auto has_config = cfgs.find(tu->GetDeviceId()) != cfgs.end();
 
       printf("%sTu addr:%08x devid:%s%04x%s trigtype:%02x trignum:%06x rawsz:%u\n",
-            prefix, (unsigned)tu->GetAddr(), 
+            prefix, (unsigned)tu->GetAddr(),
             getCol(has_config ? col_GREEN : col_RED), (unsigned)tu->GetDeviceId(), getCol(col_RESET),
             (unsigned)tu->GetTrigType(), (unsigned)tu->GetTrigNumber(),
             (unsigned)tu->GetRawPacketSize());
@@ -266,6 +271,8 @@ int main(int argc, char* argv[])
 {
    if ((argc < 2) || !strcmp(argv[1], "-help") || !strcmp(argv[1], "?"))
       return usage();
+
+   _init_ur_config();
 
    long number = 10, skip = 0, nagain = 0;
    double tmout = -1., maxage = -1.;

--- a/plugins/dogma/dldprint.cxx
+++ b/plugins/dogma/dldprint.cxx
@@ -96,22 +96,22 @@ bool is_tdc(unsigned id)
 std::map<uint32_t, TuStat> tu_stats;
 uint32_t ref_addr = 0;
 
+ur_config cfg_2051 = {
+   .coarsetime_len = 18,
+   .finetime_len = 11,
+   .tdc_type = 3,
+   .freq = 150,
+   .has_edge_type = true
+};
 
-std::unordered_map<int, ur_config> cfgs = {{2051,
-   {
-    .coarsetime_len = 18,
-    .finetime_len = 11,
-    .tdc_type = 3,
-    .freq = 150,
-    .has_edge_type = true
-  }}};
+std::unordered_map<int, ur_config> cfgs = {{2051, cfg_2051}};
 
 
 void print_tu(dogma::DogmaTu *tu, const char *prefix = "")
 {
    if (!onlytdc || (onlytdc == tu->GetAddr())) {
-      printf("%sTu addr:%08x trigtype:%02x trignum:%06x rawsz:%u\n",
-            prefix, (unsigned)tu->GetAddr(),
+      printf("%sTu addr:%08x devid:%04x trigtype:%02x trignum:%06x rawsz:%u\n",
+            prefix, (unsigned)tu->GetAddr(), (unsigned)tu->GetDeviceId(),
             (unsigned)tu->GetTrigType(), (unsigned)tu->GetTrigNumber(),
             (unsigned)tu->GetRawPacketSize());
    }
@@ -130,19 +130,15 @@ void print_tu(dogma::DogmaTu *tu, const char *prefix = "")
       ur_context it;
       ur_header h;
       ur_time tm;
+      unsigned devid = tu->GetDeviceId();
+      auto entry = cfgs.find(devid);
+      if (entry != cfgs.end())
+         ur_set_config(&it, &entry->second);
+      else
+         ur_set_config(&it, &cfg_2051);
+
       const char *buf = (const char *) tu->RawHeader();
       int pktlen = tu->GetRawPacketSize();
-
-      ur_config cfg_2051 = {
-         .coarsetime_len = 18,
-         .finetime_len = 11,
-         .tdc_type = 3,
-         .freq = 150,
-         .has_edge_type = true
-      };
-
-      ur_set_config(&it, &cfg_2051);
-
       ur_parse_header(&h, &it, buf, pktlen);
 
       double last_rising_tm = 0.;

--- a/plugins/dogma/dldprint.cxx
+++ b/plugins/dogma/dldprint.cxx
@@ -110,8 +110,12 @@ std::unordered_map<int, ur_config> cfgs = {{2051, cfg_2051}};
 void print_tu(dogma::DogmaTu *tu, const char *prefix = "")
 {
    if (!onlytdc || (onlytdc == tu->GetAddr())) {
-      printf("%sTu addr:%08x devid:%04x trigtype:%02x trignum:%06x rawsz:%u\n",
-            prefix, (unsigned)tu->GetAddr(), (unsigned)tu->GetDeviceId(),
+
+      auto has_config = cfgs.find(tu->GetDeviceId()) != cfgs.end();
+
+      printf("%sTu addr:%08x devid:%s%04x%s trigtype:%02x trignum:%06x rawsz:%u\n",
+            prefix, (unsigned)tu->GetAddr(), 
+            getCol(has_config ? col_GREEN : col_RED), (unsigned)tu->GetDeviceId(), getCol(col_RESET),
             (unsigned)tu->GetTrigType(), (unsigned)tu->GetTrigNumber(),
             (unsigned)tu->GetRawPacketSize());
    }

--- a/plugins/dogma/dldprint.cxx
+++ b/plugins/dogma/dldprint.cxx
@@ -110,10 +110,10 @@ std::unordered_map<int, ur_config> cfgs = {{2051,
 void print_tu(dogma::DogmaTu *tu, const char *prefix = "")
 {
    if (!onlytdc || (onlytdc == tu->GetAddr())) {
-      printf("%sTu addr:%08x trigtype:%02x trignum:%06x tm:%lu sz:%u\n",
+      printf("%sTu addr:%08x trigtype:%02x trignum:%06x rawsz:%u\n",
             prefix, (unsigned)tu->GetAddr(),
             (unsigned)tu->GetTrigType(), (unsigned)tu->GetTrigNumber(),
-            (long unsigned)tu->GetTrigTime(), (unsigned)tu->GetSize());
+            (unsigned)tu->GetRawPacketSize());
    }
 
    if (printraw) {

--- a/plugins/dogma/dldprint.cxx
+++ b/plugins/dogma/dldprint.cxx
@@ -98,79 +98,57 @@ uint32_t ref_addr = 0;
 
 void print_tu(dogma::DogmaTu *tu, const char *prefix = "")
 {
-   unsigned epoch0 = 0, coarse0 = 0;
-
    if (!onlytdc || (onlytdc == tu->GetAddr())) {
-      epoch0 = tu->GetTrigTime() & 0xfffffff;
-      coarse0 = tu->GetLocalTrigTime() & 0x7ff;
-      printf("%sTu addr:%06x", prefix, (unsigned)tu->GetAddr());
-      if (tu->IsMagic())
-         printf(" magic:%02x", (unsigned) tu->GetMagicType());
-      else if(tu->IsMagicTdc5())
-         printf(" tdc5:%04x", (unsigned) tu->GetMagic() & 0xffff);
-      else
-         printf(" unkn:%08x", (unsigned) tu->GetMagic());
-
-      printf(" trigtype:%02x trignum:%06x epoch0:%u tc0:%03x err:%02x frame:%02x paylod:%04x size:%u\n",
+      printf("%sTu addr:%08x trigtype:%02x trignum:%06x tm:%lu sz:%u\n",
+            prefix, (unsigned)tu->GetAddr(),
             (unsigned)tu->GetTrigType(), (unsigned)tu->GetTrigNumber(),
-            (unsigned)tu->GetTrigTime() & 0xfffffff, (unsigned)tu->GetLocalTrigTime() & 0x7ff,
-            (unsigned)tu->GetErrorBits(), (unsigned)tu->GetFrameBits(), (unsigned)tu->GetPayloadLen(), (unsigned) tu->GetSize());
+            (long unsigned)tu->GetTrigTime(), (unsigned)tu->GetSize());
    }
 
-   unsigned len = tu->GetPayloadLen();
-
    if (printraw) {
+      unsigned len = tu->GetPayloadLen();
       printf("%s", prefix);
       for (unsigned i = 0; i < len; ++i) {
-         printf("  %08x", (unsigned) tu->GetPayload(i));
-         if ((i == len - 1) || (i % 8 == 7))
+         printf(" %02x", (unsigned) tu->GetPayload(i));
+         if ((i == len - 1) || (i % 32 == 31))
             printf("\n%s", i < len-1 ? prefix : "");
       }
    } else if (is_tdc(tu->GetAddr()) || (onlytdc && (onlytdc == tu->GetAddr()))) {
-      if (tu->IsMagicDefault()) {
-         // this is convential TDC
-         std::vector<uint32_t> data(len, 0);
-         for (unsigned i = 0; i < len; ++i)
-            data[i] = tu->GetPayload(i);
-         unsigned errmask = 0;
-         PrintTdcDataPlain(0, data, strlen(prefix) + 3, errmask, false, epoch0, coarse0);
-      } else if (tu->IsMagicTdc5()) {
-         // this is new TDC5
-         tdc5_header h;
-         tdc5_parse_it it;
-         tdc5_time tm;
-         const char *buf = (const char *) tu;
-         int pktlen = (int) tu->GetTdc5PaketLength();
-         tdc5_parse_header(&h, &it, buf, pktlen);
+      // this is new TDC5
+      tdc5_header h;
+      tdc5_parse_it it;
+      tdc5_time tm;
+      const char *buf = (const char *) tu->RawHeader();
+      int pktlen = tu->GetRawPacketSize();
+      tdc5_parse_header(&h, &it, buf, pktlen);
 
-         double last_rising_tm = 0.;
-         int last_rising_ch = -1;
-         printf("%s   Trigger time: %12.9fs\n", prefix,  h.trig_time * coarse_tmlen5 * 1e-9); // time in seconds
+      double last_rising_tm = 0.;
+      int last_rising_ch = -1;
+      printf("%s   Trigger time: %12.9fs\n", prefix,  h.trig_time * coarse_tmlen5 * 1e-9); // time in seconds
 
-         // keep for debug purposes
-         if (h.trig_time != tu->GetTdc5TrigTime())
-            printf("%s   DECODING TRIGGER TIME FAILURE 0x%016lx 0x%016lx\n", prefix, (long unsigned) h.trig_time, (long unsigned) tu->GetTdc5TrigTime());
-         while (tdc5_parse_next(&tm, &it, buf, pktlen) == 1) {
-            unsigned fine = tm.fine;
-            if (fine < fine_min5)
-               fine = fine_min5;
-            else if (fine > fine_max5)
-               fine = fine_max5;
-            double fulltm = -coarse_tmlen5 * (tm.coarse + (0. + fine - fine_min5) / (0. + fine_max5 - fine_min5));
-            printf("%s   ch:%02u falling:%1d coarse:%04u fine:%03u fulltm:%7.3f",
-                         prefix, (unsigned) tm.channel, tm.is_falling,
-                         (unsigned) tm.coarse, (unsigned) tm.fine, fulltm);
-            if (tm.is_falling && (last_rising_ch == tm.channel))
-               printf("  ToT:%5.3f", fulltm - last_rising_tm);
+      // keep for debug purposes
+      // if (h.trig_time != tu->GetTdc5TrigTime())
+      //   printf("%s   DECODING TRIGGER TIME FAILURE 0x%016lx 0x%016lx\n", prefix, (long unsigned) h.trig_time, (long unsigned) tu->GetTdc5TrigTime());
+      while (tdc5_parse_next(&tm, &it, buf, pktlen) == 1) {
+         unsigned fine = tm.fine;
+         if (fine < fine_min5)
+            fine = fine_min5;
+         else if (fine > fine_max5)
+            fine = fine_max5;
+         double fulltm = -coarse_tmlen5 * (tm.coarse + (0. + fine - fine_min5) / (0. + fine_max5 - fine_min5));
+         printf("%s   ch:%02u falling:%1d coarse:%04u fine:%03u fulltm:%7.3f",
+                        prefix, (unsigned) tm.channel, tm.is_falling,
+                        (unsigned) tm.coarse, (unsigned) tm.fine, fulltm);
+         if (tm.is_falling && (last_rising_ch == tm.channel))
+            printf("  ToT:%5.3f", fulltm - last_rising_tm);
 
-            printf("\n");
-            if (!tm.is_falling) {
-               last_rising_tm = fulltm;
-               last_rising_ch = tm.channel;
-            } else {
-               last_rising_tm = 0;
-               last_rising_ch = -1;
-            }
+         printf("\n");
+         if (!tm.is_falling) {
+            last_rising_tm = fulltm;
+            last_rising_ch = tm.channel;
+         } else {
+            last_rising_tm = 0;
+            last_rising_ch = -1;
          }
       }
    }

--- a/plugins/dogma/dogma/UdpTransport.h
+++ b/plugins/dogma/dogma/UdpTransport.h
@@ -47,7 +47,7 @@ namespace dogma {
 
       uint64_t           fTotalRecvPacket{0};
       uint64_t           fTotalDiscardPacket{0};
-      uint64_t           fTotalDiscardMagic{0};
+      uint64_t           fTotalDiscardSPort{0};
       uint64_t           fTotalArtificialSkip{0};
       uint64_t           fTotalRecvBytes{0};
       uint64_t           fTotalDiscardBytes{0};
@@ -58,7 +58,7 @@ namespace dogma {
       {
          fTotalRecvPacket = 0;
          fTotalDiscardPacket = 0;
-         fTotalDiscardMagic = 0;
+         fTotalDiscardSPort = 0;
          fTotalArtificialSkip = 0;
          fTotalRecvBytes = 0;
          fTotalDiscardBytes = 0;
@@ -72,9 +72,9 @@ namespace dogma {
          return dabc::number_to_str(fTotalDiscardPacket);
       }
 
-      std::string GetDiscardMagicString()
+      std::string GetDiscardSPortString()
       {
-         std::string res = dabc::number_to_str(fTotalDiscardMagic);
+         std::string res = dabc::number_to_str(fTotalDiscardSPort);
 
          if (fTotalArtificialSkip > 0)
             res += std::string("#") + dabc::number_to_str(fTotalArtificialSkip);
@@ -98,6 +98,7 @@ namespace dogma {
          std::string        fHostName;           ///< host name used to create UDP socket
          int                fRecvBufLen{100000}; ///< recv buf len
          std::string        fMcastAddr;          ///< mcast address
+         int                fSourcePort{0};      ///< allowed source port
          unsigned           fMTU{0};             ///< maximal size of packet expected from DOG
          void*              fMtuBuffer{nullptr}; ///< buffer used to skip packets when no normal buffer is available
          int                fSkipCnt{0};         ///< counter used to control buffers skipping
@@ -122,7 +123,7 @@ namespace dogma {
          bool CloseBuffer();
 
       public:
-         UdpAddon(int fd, const std::string &host, int nport, int rcvbuflen, const std::string &mcast, int mtu, bool debug, bool print, int maxloop, double reduce);
+         UdpAddon(int fd, const std::string &host, int nport, int sport, int rcvbuflen, const std::string &mcast, int mtu, bool debug, bool print, int maxloop, double reduce);
          ~UdpAddon() override;
 
          bool HasBuffer() const { return !fTgtPtr.null(); }

--- a/plugins/dogma/dogma/defines.h
+++ b/plugins/dogma/dogma/defines.h
@@ -36,7 +36,6 @@ namespace dogma {
 
    struct DogmaTu {
       protected:
-         uint32_t tuMagic = 0;
          uint32_t tuAddr = 0;
          uint32_t tuDeviceId = 0;
          uint32_t tuLenPayload = 0; // number of bytes in payload
@@ -45,10 +44,6 @@ namespace dogma {
          uint32_t tuTrigTypeNumber = 0;
 
       public:
-
-         inline uint32_t GetMagic() const { return SWAP_VALUE(tuMagic); }
-
-         inline bool IsMagic() const { return (SWAP_VALUE(tuMagic) == DOGMA_MAGIC); }
 
          inline uint32_t GetAddr() const { return SWAP_VALUE(tuAddr); }
 
@@ -84,8 +79,6 @@ namespace dogma {
 
          void *RawData() const { return (char *) this + sizeof(DogmaTu); }
 
-         inline void SetMagic() { tuMagic = SWAP_VALUE(DOGMA_MAGIC); }
-
          inline void SetAddr(uint32_t addr) { tuAddr = SWAP_VALUE(addr); }
 
          inline void SetDeviceId(uint32_t id) { tuDeviceId = SWAP_VALUE(id); }
@@ -101,7 +94,6 @@ namespace dogma {
 
          void Init(uint32_t type_number)
          {
-            tuMagic = SWAP_VALUE(DOGMA_MAGIC);
             tuAddr = 0;
             tuDeviceId = 0;
             SetTrigTypeNumber(type_number);
@@ -114,14 +106,11 @@ namespace dogma {
 
    struct DogmaEvent {
       protected:
-         uint32_t tuMagic = 0;
          uint32_t tuSeqId = 0;
          uint32_t tuTrigTypeNumber = 0;
          uint32_t tuLenPayload = 0; // payload len in 4bytes words
 
       public:
-
-         inline bool IsMagic() const { return (SWAP_VALUE(tuMagic) & 0xffffff00) == (DOGMA_MAGIC & 0xffffff00); }
 
          inline uint32_t GetSeqId() const { return SWAP_VALUE(tuSeqId); }
          inline uint32_t GetTrigType() const { return SWAP_VALUE(tuTrigTypeNumber) >> 24; }
@@ -131,7 +120,6 @@ namespace dogma {
 
          void Init(uint32_t seqid, uint32_t trig_type, uint32_t trig_number)
          {
-            tuMagic = SWAP_VALUE(DOGMA_MAGIC);
             tuSeqId = SWAP_VALUE(seqid);
             uint32_t v = (trig_type << 24) | (trig_number & 0xffffff);
             tuTrigTypeNumber = SWAP_VALUE(v);

--- a/plugins/dogma/dogma/defines.h
+++ b/plugins/dogma/dogma/defines.h
@@ -73,7 +73,7 @@ namespace dogma {
          }
 
          // this points on the start of raw header send from front end
-         void *RawHeader() const { return (char *) this + 16; }
+         void *RawHeader() const { return (char *) this + 12; }
 
          uint32_t GetRawPacketSize() const { return GetPayloadLen() + 12; }
 

--- a/plugins/dogma/dogma/defines.h
+++ b/plugins/dogma/dogma/defines.h
@@ -24,113 +24,89 @@
 
 #define DOGMA_MAGIC 0xecc1701d
 
-#define TDC5_MAGIC 0x55520000
-
 #define SWAP_VALUE(v) (((v & 0xFF) << 24) | ((v & 0xFF00) << 8) | ((v & 0xFF0000) >> 8) | ((v & 0xFF000000) >> 24))
 
 namespace dogma {
 
    /** \brief DOGMA transport unit header
     *
-    * used as base for event and subevent
+    * used for subevents transport
     * also common envelope for trd network data packets
     */
 
    struct DogmaTu {
       protected:
          uint32_t tuMagic = 0;
-         uint32_t tuTrigTypeNumber = 0;
          uint32_t tuAddr = 0;
-         uint32_t tuTrigTime = 0;
-         uint32_t tuLocalTrigTime = 0;
-         uint32_t tuLenPayload = 0; // number of 4bytes words
+         uint32_t tuDeviceId = 0;
+         uint32_t tuLenPayload = 0; // number of bytes in payload
+         uint32_t tuTrigTimeHigh = 0;
+         uint32_t tuTrigTimeLow = 0;
+         uint32_t tuTrigTypeNumber = 0;
 
       public:
 
-         inline bool IsMagic() const { return (SWAP_VALUE(tuMagic) & 0xffffff00) == (DOGMA_MAGIC & 0xffffff00); }
-
-         inline bool IsMagicTdc5() const { return (SWAP_VALUE(tuMagic) & 0xffff0000) == (TDC5_MAGIC & 0xffff0000); }
-
-         inline uint32_t GetMagicType() const { return SWAP_VALUE(tuMagic) & 0xff; }
-
-         inline bool IsMagicDefault() const { return GetMagicType() == (DOGMA_MAGIC & 0xff); }
-
          inline uint32_t GetMagic() const { return SWAP_VALUE(tuMagic); }
+
+         inline bool IsMagic() const { return (SWAP_VALUE(tuMagic) == DOGMA_MAGIC); }
 
          inline uint32_t GetAddr() const { return SWAP_VALUE(tuAddr); }
 
-         inline uint32_t GetTrigType() const
-         {
-            auto v = SWAP_VALUE(tuTrigTypeNumber);
-            return IsMagicTdc5() ? v >> 28 : v >> 24;
-         }
+         inline uint32_t GetDeviceId() const { return SWAP_VALUE(tuDeviceId); }
 
-         inline uint32_t GetTrigNumber() const { return SWAP_VALUE(tuTrigTypeNumber) & 0xffffff; }
+         inline uint32_t GetTrigType() const { return SWAP_VALUE(tuTrigTypeNumber) >> 28; }
+
+         inline uint32_t GetTrigNumber() const { return SWAP_VALUE(tuTrigTypeNumber) & 0xfffffff; }
 
          inline uint32_t GetTrigTypeNumber() const { return SWAP_VALUE(tuTrigTypeNumber); }
 
-         inline uint32_t GetTrigTime() const { return SWAP_VALUE(tuTrigTime); }
+         inline uint64_t GetTrigTime() const { return (((uint64_t) SWAP_VALUE(tuTrigTimeHigh)) << 32) | SWAP_VALUE(tuTrigTimeLow); }
 
-         inline uint32_t GetLocalTrigTime() const { return SWAP_VALUE(tuLocalTrigTime); }
+         inline uint32_t GetPayloadLen() const { return SWAP_VALUE(tuLenPayload); }
 
-         inline uint64_t GetTdc5TrigTime() const { return (((uint64_t) GetTrigTime()) << 32) | GetLocalTrigTime(); }
-
-         inline uint32_t GetPayloadLen() const { return SWAP_VALUE(tuLenPayload) & 0xffff; }
-
-         inline uint32_t GetErrorBits() const { return SWAP_VALUE(tuLenPayload) >> 24; }
-
-         inline uint32_t GetFrameBits() const { return (SWAP_VALUE(tuLenPayload) >> 16) & 0xff; }
-
-         inline void SetPayloadLen(uint32_t len)
+         // size always rounded to 4 bytes and includes header
+         inline uint32_t GetSize() const
          {
-            uint32_t new_payload = (len & 0xffff) | (SWAP_VALUE(tuLenPayload) & 0xffff0000);
-            tuLenPayload = SWAP_VALUE(new_payload);
+            uint32_t len = GetPayloadLen(), cut = len % 4;
+            return sizeof(DogmaTu) + len + (cut > 0 ? 4 - cut : 0);
          }
 
-         inline void SetFrameBits(uint32_t bits)
+         inline uint8_t GetPayload(uint32_t indx) const
          {
-            uint32_t new_payload = ((bits << 16) & 0xff0000) | (SWAP_VALUE(tuLenPayload) & 0xff00ffff);
-            tuLenPayload = SWAP_VALUE(new_payload);
+            uint8_t *beg = (uint8_t *)(&tuLenPayload + 4);
+            return *(beg + indx);
          }
 
-         inline uint32_t SetTdc5PaketLength(uint32_t sz)
-         {
-            if (sz < sizeof(DogmaTu))
-               sz = sizeof(DogmaTu);
-            uint32_t sz4 = sz / 4, odd_len = sz - sz4 * 4;
-            if (odd_len > 0)
-               sz4++;
-            SetPayloadLen(sz4 - sizeof(DogmaTu) / 4);
-            SetFrameBits(odd_len); // store in frame bits extra bytes not match to 4 bytes borders
-            return sz4 * 4;
-         }
+         // this points on the start of raw header send from front end
+         void *RawHeader() const { return (char *) this + 16; }
 
-         inline uint32_t GetTdc5PaketLength() const
-         {
-            uint32_t sz = GetSize(),
-                     odd_len = GetFrameBits();
-            return (odd_len > 0) && (sz >= 4) ? sz + odd_len - 4 : sz;
-         }
-
-         inline uint32_t GetSize() const { return sizeof(DogmaTu) + GetPayloadLen() * 4; }
-
-         inline uint32_t GetPayload(uint32_t indx) const
-         {
-            uint32_t v = *(&tuLenPayload + 1 + indx);
-            return SWAP_VALUE(v);
-         }
+         uint32_t GetRawPacketSize() const { return GetPayloadLen() + 12; }
 
          void *RawData() const { return (char *) this + sizeof(DogmaTu); }
 
+         inline void SetMagic() { tuMagic = SWAP_VALUE(DOGMA_MAGIC); }
+
+         inline void SetAddr(uint32_t addr) { tuAddr = SWAP_VALUE(addr); }
+
+         inline void SetDeviceId(uint32_t id) { tuDeviceId = SWAP_VALUE(id); }
+
          void SetTrigTypeNumber(uint32_t type_number) { tuTrigTypeNumber = SWAP_VALUE(type_number); }
+
+         inline void SetPayloadLen(uint32_t len) { tuLenPayload = SWAP_VALUE(len); }
+
+         inline void SetRawPacketSize(uint32_t sz)
+         {
+            SetPayloadLen(sz > 12 ? sz - 12 : 0);
+         }
 
          void Init(uint32_t type_number)
          {
             tuMagic = SWAP_VALUE(DOGMA_MAGIC);
             tuAddr = 0;
+            tuDeviceId = 0;
             SetTrigTypeNumber(type_number);
-            tuTrigTime = 0;
-            tuLocalTrigTime = 0;
+            tuTrigTimeHigh = 0;
+            tuTrigTimeLow = 0;
             tuLenPayload = 0;
          }
 
@@ -150,6 +126,8 @@ namespace dogma {
          inline uint32_t GetSeqId() const { return SWAP_VALUE(tuSeqId); }
          inline uint32_t GetTrigType() const { return SWAP_VALUE(tuTrigTypeNumber) >> 24; }
          inline uint32_t GetTrigNumber() const { return SWAP_VALUE(tuTrigTypeNumber) & 0xffffff; }
+         inline uint32_t GetPayloadLen() const { return SWAP_VALUE(tuLenPayload) & 0xffff; }
+         inline uint32_t GetEventLen() const { return sizeof(DogmaEvent) + GetPayloadLen() * 4; }
 
          void Init(uint32_t seqid, uint32_t trig_type, uint32_t trig_number)
          {
@@ -160,12 +138,11 @@ namespace dogma {
             tuLenPayload = 0;
          }
 
-         inline uint32_t GetPayloadLen() const { return SWAP_VALUE(tuLenPayload) & 0xffff; }
          inline void SetPayloadLen(uint32_t len) { tuLenPayload = SWAP_VALUE(len); }
 
-         inline uint32_t GetEventLen() const { return sizeof(DogmaEvent) + GetPayloadLen() * 4; }
+         inline void SetEventLen(uint32_t sz) { SetPayloadLen((sz - sizeof(DogmaEvent)) / 4); }
 
-         DogmaTu *FirstSubevent() const { return (DogmaTu *)((char *) this + sizeof(DogmaEvent)); }
+         inline DogmaTu *FirstSubevent() const { return GetPayloadLen() * 4 < sizeof(DogmaTu) ? nullptr : (DogmaTu *)((char *) this + sizeof(DogmaEvent)); }
 
          DogmaTu *NextSubevent(DogmaTu *prev) const
          {

--- a/plugins/dogma/dogma/defines.h
+++ b/plugins/dogma/dogma/defines.h
@@ -39,9 +39,9 @@ namespace dogma {
          uint32_t tuAddr = 0;
          uint32_t tuDeviceId = 0;
          uint32_t tuLenPayload = 0; // number of bytes in payload
+         uint32_t tuTrigTypeNumber = 0;
          uint32_t tuTrigTimeHigh = 0;
          uint32_t tuTrigTimeLow = 0;
-         uint32_t tuTrigTypeNumber = 0;
 
       public:
 

--- a/plugins/dogma/dogma/ur-unpacker.h
+++ b/plugins/dogma/dogma/ur-unpacker.h
@@ -1,0 +1,183 @@
+#pragma once
+
+#include <stdint.h>
+
+#include <stdint.h>
+
+/* Detect big-endian hosts */
+#if defined(__BYTE_ORDER__) && defined(__ORDER_BIG_ENDIAN__) &&                \
+    (__BYTE_ORDER__ == __ORDER_BIG_ENDIAN__)
+#define HOST_BIG_ENDIAN 1
+#endif
+
+/* Big-endian: no-op */
+#ifdef HOST_BIG_ENDIAN
+
+static inline uint16_t be16conv(uint16_t x) { return x; }
+static inline uint32_t be32conv(uint32_t x) { return x; }
+static inline uint64_t be64conv(uint64_t x) { return x; }
+
+#else /* Little-endian (Windows, macOS, Linux, etc.) */
+
+static inline uint16_t be16conv(uint16_t x) {
+  return (uint16_t)((x >> 8) | (x << 8));
+}
+
+static inline uint32_t be32conv(uint32_t x) {
+  return ((x & 0x000000FFU) << 24) | ((x & 0x0000FF00U) << 8) |
+         ((x & 0x00FF0000U) >> 8) | ((x & 0xFF000000U) >> 24);
+}
+
+static inline uint64_t be64conv(uint64_t x) {
+  return ((uint64_t)be32conv((uint32_t)x) << 32) |
+         be32conv((uint32_t)(x >> 32));
+}
+#endif
+
+struct ur_context {
+  int i;
+  int cur_chan;
+  int is_first;
+  uint64_t last_time;
+  uint8_t block_flags;
+  int coarsetime_len, finetime_len, bitpadding_len, is_small, has_edge_type;
+  int ft0_len, coarsetime_offset, edgetype_offset, remaining_ft_bytes;
+};
+struct ur_config {
+  int coarsetime_len, finetime_len, tdc_type, freq, has_edge_type;
+};
+struct ur_header {
+  // uint32_t magic;
+  uint8_t trig_type;
+  uint32_t trig_num;
+  // uint32_t device_id;
+  uint64_t trig_time;
+  // int coarsetime_len, tdc_type, freq, finetime_len, has_edge_type;
+};
+struct ur_time {
+  int channel;
+  uint32_t coarse;
+  uint8_t payload[128]; // 1024 bit finetimes are the maximum, because the
+                        // header cannot indicate more
+  uint32_t fine;
+  int is_falling;
+};
+
+inline void ur_set_config(ur_context *it, const ur_config *cfg)
+{
+  it->coarsetime_len = cfg->coarsetime_len;
+  it->finetime_len = cfg->finetime_len;
+  it->has_edge_type = cfg->has_edge_type;
+  // std::cout << it->coarsetime_len << " " << it->finetime_len << " " << it->has_edge_type << std::endl;
+
+  int full_width =
+      it->coarsetime_len + it->finetime_len + it->has_edge_type + 2;
+  // std::cout << "FULL " << full_width << std::endl;
+  it->bitpadding_len = (8 - (full_width % 8)) % 8;
+  it->is_small = it->bitpadding_len + full_width <= 24;
+
+  int ft0_len_max = 30 - it->coarsetime_len - it->bitpadding_len -
+                    it->has_edge_type; // max amount of FT bits that fit into
+                                       // the first 32 bit word
+
+  it->ft0_len =
+      std::min(ft0_len_max, it->finetime_len); // the actual amount of FT bits
+                                               // in the first 32 bit word
+  it->coarsetime_offset = it->ft0_len + it->has_edge_type + it->bitpadding_len;
+  it->edgetype_offset = it->has_edge_type ? ft0_len_max : 31;
+  it->remaining_ft_bytes =
+      (it->finetime_len - it->ft0_len) /
+      8; // FT bytes we need to load after the first 32 bit word
+}
+
+inline void ur_parse_header(ur_header *h, ur_context *it, const char *buf,
+                            int n) {
+  it->i = 0;
+  h->trig_time = be64conv(*(uint64_t *)(buf + it->i));
+  it->i += 8;
+  uint32_t trig_type_num = be32conv(*(uint32_t *)(buf + it->i));
+  it->i += 4;
+  h->trig_type = trig_type_num >> 28;
+  h->trig_num = trig_type_num & 0x0fffffff;
+  it->cur_chan = 0;
+  it->is_first = 1;
+}
+inline int ur_parse_next(
+    ur_time *res, ur_context *it, const char *buf,
+    int n) // return codes: negative: error; zero: success; positive: continue
+{
+  // skip empty channels
+  int is_channel_empty;
+  do {
+    if (it->i == n) { // stream finished
+      return it->is_first ? 0 : -1;
+    }
+
+    is_channel_empty = 0;
+    if (it->is_first) { // this is the first word/time in the channel sequence
+      if ((it->cur_chan & 7) == 0) { // ... the first channel in a channel block
+                                     // consisting of 8 channels
+        if (it->i == n)
+          return -1;
+        it->block_flags = buf[it->i++]; // load 8 channel flags
+      }
+      // check if current channel is empty and shift flags s.t. flag of the next
+      // channel is the LSB
+      is_channel_empty = !(it->block_flags & 1);
+      it->block_flags >>= 1;
+
+      it->last_time = 0;
+
+      if (is_channel_empty) {
+        it->is_first = 1;
+        ++it->cur_chan;
+      }
+    }
+  } while (is_channel_empty);
+
+  // decode times
+  if (it->i + 3 > n)
+    return -1;
+  uint16_t msbs = be16conv(*(uint16_t *)(buf + it->i));
+  it->i += 2;
+  int is_last = !!(msbs & 0x8000);
+  int is_ext = !!(msbs & 0x4000);
+  msbs = msbs & 0x3fff;
+  int lsb_time_len = !it->is_small + is_ext;
+  if (it->i + lsb_time_len > n)
+    return -1;
+  uint16_t lsbs = is_ext && !it->is_small ? be16conv(*(uint16_t *)(buf + it->i))
+                  : !is_ext || it->is_small ? (uint8_t)buf[it->i]
+                                            : 0;
+  it->i += lsb_time_len;
+  uint32_t time = (((uint32_t)msbs) << (lsb_time_len * 8)) | lsbs;
+
+  // extract t0, diff and edgetype from "time"
+  uint32_t t0 = time & ((1 << it->ft0_len) - 1);
+  int32_t diff = time >> it->coarsetime_offset;
+  res->is_falling = (time >> it->edgetype_offset) & 1;
+
+  int off = (it->ft0_len + 7) / 8;
+  res->fine = t0;
+  for (int i = 0; i < off; ++i) {
+    res->payload[off - 1 - i] = t0 & 255;
+    t0 >>= 8;
+  }
+  for (int i = 0; i < it->remaining_ft_bytes; ++i) {
+    res->payload[off + i] = (uint8_t)buf[it->i++];
+  }
+
+  it->last_time = it->is_first ? diff : it->last_time - diff;
+  res->coarse = it->last_time;
+  res->channel = it->cur_chan;
+
+  it->is_first =
+      is_last; // if this is the last time from the current channel, the next
+               // time will be the first one from the next channel...
+
+  if (is_last) {
+    ++it->cur_chan;
+  }
+
+  return 1;
+}

--- a/plugins/dogma/dogma/ur-unpacker.h
+++ b/plugins/dogma/dogma/ur-unpacker.h
@@ -93,10 +93,10 @@ inline void ur_set_config(ur_context *it, const ur_config *cfg)
 inline void ur_parse_header(ur_header *h, ur_context *it, const char *buf,
                             int n) {
   it->i = 0;
-  h->trig_time = be64conv(*(uint64_t *)(buf + it->i));
-  it->i += 8;
   uint32_t trig_type_num = be32conv(*(uint32_t *)(buf + it->i));
   it->i += 4;
+  h->trig_time = be64conv(*(uint64_t *)(buf + it->i));
+  it->i += 8;
   h->trig_type = trig_type_num >> 28;
   h->trig_num = trig_type_num & 0x0fffffff;
   it->cur_chan = 0;

--- a/plugins/dogma/src/CombinerModule.cxx
+++ b/plugins/dogma/src/CombinerModule.cxx
@@ -578,14 +578,14 @@ void dogma::CombinerModule::UpdateBnetInfo()
             }
 
             inp.fHubLastSize = info->fTotalRecvBytes;
-            sinfo = dabc::format("port:%d %5.3f MB/s data:%s pkts:%s buf:%s disc:%s magic:%s drop:%s lost:%s ",
+            sinfo = dabc::format("port:%d %5.3f MB/s data:%s pkts:%s buf:%s disc:%s sport:%s drop:%s lost:%s ",
                        info->fNPort,
                        rate,
                        dabc::size_to_str(info->fTotalRecvBytes).c_str(),
                        dabc::number_to_str(info->fTotalRecvPacket,1).c_str(),
                        dabc::number_to_str(info->fTotalProducedBuffers).c_str(),
                        info->GetDiscardString().c_str(),
-                       info->GetDiscardMagicString().c_str(),
+                       info->GetDiscardSPortString().c_str(),
                        dabc::number_to_str(inp.fDroppedTrig,0).c_str(),
                        dabc::number_to_str(inp.fLostTrig,0).c_str());
 

--- a/plugins/dogma/src/Factory.cxx
+++ b/plugins/dogma/src/Factory.cxx
@@ -101,6 +101,7 @@ dabc::Module* dogma::Factory::CreateTransport(const dabc::Reference& port, const
    int maxloop = url.GetOptionInt("maxloop", 100);
    double flush = url.GetOptionDouble(dabc::xml_flush, 1.);
    double reduce = url.GetOptionDouble("reduce", 1.);
+   int sport = url.GetOptionInt("sport", 0);
    bool debug = url.HasOption("debug");
    bool print = url.HasOption("print");
    int udp_queue = url.GetOptionInt("upd_queue", 0);
@@ -111,6 +112,6 @@ dabc::Module* dogma::Factory::CreateTransport(const dabc::Reference& port, const
 
    DOUT0("Start DOGMA UDP transport on %s", url.GetHostNameWithPort().c_str());
 
-   auto addon = new dogma::UdpAddon(fd, host, nport, rcvbuflen, mcast, mtu, debug, print, maxloop, reduce);
+   auto addon = new dogma::UdpAddon(fd, host, nport, sport, rcvbuflen, mcast, mtu, debug, print, maxloop, reduce);
 	return new dogma::UdpTransport(cmd, portref, addon, flush, heartbeat);
 }

--- a/plugins/dogma/src/TerminalModule.cxx
+++ b/plugins/dogma/src/TerminalModule.cxx
@@ -277,7 +277,7 @@ void dogma::TerminalModule::ProcessTimerEvent(unsigned)
         }
       }
 
-   s += "inp port     pkt      data    MB/s   disc  magic   bufs  qu  drop  lost";
+   s += "inp port     pkt      data    MB/s   disc  sport   bufs  qu  drop  lost";
    if (show_bad)
       s+= "  bad";
    if (istdccal) s += "    TRB         TDC               progr   state";

--- a/plugins/dogma/src/TerminalModule.cxx
+++ b/plugins/dogma/src/TerminalModule.cxx
@@ -320,7 +320,7 @@ void dogma::TerminalModule::ProcessTimerEvent(unsigned)
                dabc::size_to_str(info->fTotalRecvBytes).c_str(),
                rate/1024./1024.,
                info->GetDiscardString().c_str(),
-               info->GetDiscardMagicString().c_str(),
+               info->GetDiscardSPortString().c_str(),
                dabc::number_to_str(info->fTotalProducedBuffers).c_str()));
          fCalibr[n].lastrecv = info->fTotalRecvBytes;
 

--- a/plugins/dogma/src/UdpTransport.cxx
+++ b/plugins/dogma/src/UdpTransport.cxx
@@ -34,13 +34,14 @@
 // according to specification maximal UDP packet is 65,507 or 0xFFE3
 #define DEFAULT_MTU 0xFFF0
 
-dogma::UdpAddon::UdpAddon(int fd, const std::string &host, int nport, int rcvbuflen, const std::string &mcast, int mtu, bool debug, bool print, int maxloop, double reduce) :
+dogma::UdpAddon::UdpAddon(int fd, const std::string &host, int nport, int sport, int rcvbuflen, const std::string &mcast, int mtu, bool debug, bool print, int maxloop, double reduce) :
    dabc::SocketAddon(fd),
    TransportInfo(nport),
    fTgtPtr(),
    fHostName(host),
    fRecvBufLen(rcvbuflen),
    fMcastAddr(mcast),
+   fSourcePort(sport),
    fMTU(mtu > 0 ? mtu : DEFAULT_MTU),
    fMtuBuffer(nullptr),
    fSkipCnt(0),
@@ -194,8 +195,8 @@ bool dogma::UdpAddon::ReadUdp()
 
       // DOUT0("Get packet from source %u port %u port2 %u", *((uint32_t *) &addr.sin_addr), (unsigned) addr.sin_port, (unsigned) ntohs(addr.sin_port));
 
-      if (ntohs(addr.sin_port) != 2051) {
-         fTotalDiscardMagic++;
+      if ((fSourcePort > 0) && (ntohs(addr.sin_port) != fSourcePort)) {
+         fTotalDiscardSPort++;
          errmsg = "Source port is not recognized";
       }
 

--- a/plugins/dogma/src/UdpTransport.cxx
+++ b/plugins/dogma/src/UdpTransport.cxx
@@ -165,7 +165,7 @@ bool dogma::UdpAddon::ReadUdp()
 
       // frond end sends fields starting from trigger time
       // so first members need to be initialized ourselfs
-      ssize_t res = recvfrom(Socket(), (char *) tgt + 16, fMTU - 16, MSG_DONTWAIT, (sockaddr *) &addr, &socklen);
+      ssize_t res = recvfrom(Socket(), (char *) tgt + 12, fMTU - 12, MSG_DONTWAIT, (sockaddr *) &addr, &socklen);
 
       // ssize_t res = recv(Socket(), tgt, fMTU, MSG_DONTWAIT);
 
@@ -188,10 +188,9 @@ bool dogma::UdpAddon::ReadUdp()
 
       std::string errmsg;
 
-      tu->SetMagic();
       tu->SetAddr(*((uint32_t *) &addr.sin_addr));
       tu->SetDeviceId(addr.sin_port);
-      tu->SetRawPacketSize(res); // total tu size includes 16 bytes length
+      tu->SetRawPacketSize(res); // total tu size includes extra 12 bytes in header and aligned to 4 bytes boundary
 
       if (addr.sin_port != 2051) {
          fTotalDiscardMagic++;

--- a/plugins/dogma/src/UdpTransport.cxx
+++ b/plugins/dogma/src/UdpTransport.cxx
@@ -160,7 +160,14 @@ bool dogma::UdpAddon::ReadUdp()
       //  socklen_t socklen = sizeof(fSockAddr);
       //  ssize_t res = recvfrom(Socket(), fTgtPtr.ptr(), fMTU, 0, (sockaddr*) &fSockAddr, &socklen);
 
-      ssize_t res = recv(Socket(), tgt, fMTU, MSG_DONTWAIT);
+      sockaddr_in addr;
+      socklen_t socklen = sizeof(addr);
+
+      // frond end sends fields starting from trigger time
+      // so first members need to be initialized ourselfs
+      ssize_t res = recvfrom(Socket(), (char *) tgt + 16, fMTU - 16, MSG_DONTWAIT, (sockaddr *) &addr, &socklen);
+
+      // ssize_t res = recv(Socket(), tgt, fMTU, MSG_DONTWAIT);
 
       PROFILER_BLOCK("chk")
 
@@ -178,21 +185,17 @@ bool dogma::UdpAddon::ReadUdp()
       }
 
       auto tu = static_cast<DogmaTu *>(tgt);
-      uint32_t msgsize = 0;
 
       std::string errmsg;
 
-      if (tu->IsMagicTdc5()) {
-         msgsize = tu->SetTdc5PaketLength(res); // total size will be rounded by 4 bytes boundary
-         if ((msgsize < res) || (msgsize > res + 3))
-            errmsg = dabc::format("Failure by coding packet len %u in tu size %u - ignore it", (unsigned) res, (unsigned) msgsize);
-      } else if (tu->IsMagic() && tu->IsMagicDefault()) {
-         msgsize = tu->GetSize(); // size must match with number of received bytes
-         if (res != msgsize)
-            errmsg = dabc::format("Send buffer %u differ from message size %u - ignore it", (unsigned) res, (unsigned) msgsize);
-      } else {
+      tu->SetMagic();
+      tu->SetAddr(*((uint32_t *) &addr.sin_addr));
+      tu->SetDeviceId(addr.sin_port);
+      tu->SetRawPacketSize(res); // total tu size includes 16 bytes length
+
+      if (addr.sin_port != 2051) {
          fTotalDiscardMagic++;
-         errmsg = "Magic subtype not match";
+         errmsg = "Source port is not recognized";
       }
 
       if (!errmsg.empty()) {
@@ -217,7 +220,7 @@ bool dogma::UdpAddon::ReadUdp()
       fTotalRecvPacket++;
       fTotalRecvBytes += res;
 
-      fTgtPtr.shift(msgsize);
+      fTgtPtr.shift(tu->GetSize());
 
 
       PROFILER_BLOCK("buf2")

--- a/plugins/dogma/src/UdpTransport.cxx
+++ b/plugins/dogma/src/UdpTransport.cxx
@@ -192,6 +192,8 @@ bool dogma::UdpAddon::ReadUdp()
       tu->SetDeviceId(addr.sin_port);
       tu->SetRawPacketSize(res); // total tu size includes extra 12 bytes in header and aligned to 4 bytes boundary
 
+      DOUT0("Get packet from source %u port %u port2 %u", *((uint32_t *) &addr.sin_addr), (unsigned) addr.sin_port, (unsigned) ntohs(addr.sin_port));
+
       if (addr.sin_port != 2051) {
          fTotalDiscardMagic++;
          errmsg = "Source port is not recognized";

--- a/plugins/dogma/src/UdpTransport.cxx
+++ b/plugins/dogma/src/UdpTransport.cxx
@@ -188,13 +188,13 @@ bool dogma::UdpAddon::ReadUdp()
 
       std::string errmsg;
 
-      tu->SetAddr(*((uint32_t *) &addr.sin_addr));
-      tu->SetDeviceId(addr.sin_port);
+      tu->SetAddr(ntohl(addr.sin_addr.s_addr));
+      tu->SetDeviceId(ntohs(addr.sin_port));
       tu->SetRawPacketSize(res); // total tu size includes extra 12 bytes in header and aligned to 4 bytes boundary
 
-      DOUT0("Get packet from source %u port %u port2 %u", *((uint32_t *) &addr.sin_addr), (unsigned) addr.sin_port, (unsigned) ntohs(addr.sin_port));
+      // DOUT0("Get packet from source %u port %u port2 %u", *((uint32_t *) &addr.sin_addr), (unsigned) addr.sin_port, (unsigned) ntohs(addr.sin_port));
 
-      if (addr.sin_port != 2051) {
+      if (ntohs(addr.sin_port) != 2051) {
          fTotalDiscardMagic++;
          errmsg = "Source port is not recognized";
       }


### PR DESCRIPTION
Use UDP source port as device id - type of TDC, frequency, ...
And UDP source ip as unique endpoint address. So now TDC will have 32 bits address space
And also UDP packet size will be written to header to be able put many sub-events (TUs) together in one event

So this PR introduces new DLD format where less data transported via UDP but then missing bytes in header filled from
UDP information. 