### PR TITLE
Implement mbs "legacy" for server 

### DIFF
--- a/base/dabc/SocketThread.h
+++ b/base/dabc/SocketThread.h
@@ -225,8 +225,8 @@ namespace dabc {
          bool StartSend(const Buffer& buf);
          bool StartRecv(Buffer& buf, BufferSize_t datasize);
 
-         bool StartNetRecv(void* hdr, unsigned hdrsize, Buffer& buf, BufferSize_t datasize);
-         bool StartNetSend(void* hdr, unsigned hdrsize, const Buffer& buf);
+         bool StartNetRecv(void *hdr, unsigned hdrsize, Buffer &buf, BufferSize_t datasize);
+         bool StartNetSend(void *hdr, unsigned hdrsize, const Buffer &buf, BufferSize_t datasize = 0);
 
          /** \brief Method should be used to cancel all running I/O operation of the socket.
           * Should be used for instance when worker want to be deleted */

--- a/base/src/SocketThread.cxx
+++ b/base/src/SocketThread.cxx
@@ -412,12 +412,12 @@ bool dabc::SocketIOAddon::StartSend(const void* buf1, unsigned size1,
 }
 
 
-bool dabc::SocketIOAddon::StartRecv(void* buf, size_t size)
+bool dabc::SocketIOAddon::StartRecv(void *buf, size_t size)
 {
    return StartRecvHdr(nullptr, 0, buf, size);
 }
 
-bool dabc::SocketIOAddon::StartSend(const Buffer& buf)
+bool dabc::SocketIOAddon::StartSend(const Buffer &buf)
 {
    // this is simple version,
    // where only buffer itself without header is transported
@@ -425,14 +425,15 @@ bool dabc::SocketIOAddon::StartSend(const Buffer& buf)
    return StartNetSend(nullptr, 0, buf);
 }
 
-bool dabc::SocketIOAddon::StartRecvHdr(void* hdr, unsigned hdrsize, void* buf, size_t size)
+bool dabc::SocketIOAddon::StartRecvHdr(void *hdr, unsigned hdrsize, void *buf, size_t size)
 {
-   if (fRecvIOVNumber>0) {
+   if (fRecvIOVNumber > 0) {
       EOUT("Current recv operation not yet completed");
       return false;
    }
 
-   if (fRecvIOVSize<2) AllocateRecvIOV(8);
+   if (fRecvIOVSize < 2)
+      AllocateRecvIOV(8);
 
    int indx = 0;
 
@@ -506,16 +507,18 @@ bool dabc::SocketIOAddon::StartNetRecv(void* hdr, unsigned hdrsize, Buffer& buf,
    return true;
 }
 
-bool dabc::SocketIOAddon::StartNetSend(void* hdr, unsigned hdrsize, const Buffer& buf)
+bool dabc::SocketIOAddon::StartNetSend(void *hdr, unsigned hdrsize, const Buffer &buf, dabc::BufferSize_t datasize)
 {
    if (fSendIOVNumber > 0) {
       EOUT("Current send operation not yet completed");
       return false;
    }
 
-   if (buf.null()) return false;
+   if (buf.null())
+      return false;
 
-   if (fSendIOVSize<=buf.NumSegments()) AllocateSendIOV(buf.NumSegments()+1);
+   if (fSendIOVSize <= buf.NumSegments())
+      AllocateSendIOV(buf.NumSegments()+1);
 
    fSendUseMsg = fUseMsgOper;
    fSendIOVFirst = 0;
@@ -528,11 +531,21 @@ bool dabc::SocketIOAddon::StartNetSend(void* hdr, unsigned hdrsize, const Buffer
       indx++;
    }
 
-   for (unsigned nseg=0; nseg<buf.NumSegments(); nseg++) {
+   bool send_more = datasize > 0;
+   long send_remain = datasize;
+
+   for (unsigned nseg = 0; nseg < buf.NumSegments(); nseg++) {
       fSendIOV[indx].iov_base = buf.SegmentPtr(nseg);
       fSendIOV[indx].iov_len = buf.SegmentSize(nseg);
+      if (send_more)
+         send_remain -= fSendIOV[indx].iov_len;
       indx++;
    }
+
+   // if more bytes want to be send, we suppose that segment has valid memory behind
+   // mode is used for legacy MBS which want to send full buffer at the end
+   if (send_more && send_remain > 0)
+      fSendIOV[indx-1].iov_len += send_remain;
 
    fSendIOVNumber = indx;
 

--- a/plugins/mbs/mbs/ServerTransport.h
+++ b/plugins/mbs/mbs/ServerTransport.h
@@ -70,7 +70,8 @@ namespace mbs {
          mbs::SubeventHeader   fSubHdr; // additional MBS subevent header (for non-MBS events)
          uint32_t              fEvCounter{0}; // special events counter
          uint32_t              fSubevId{0};  // full id of subevent
-         bool                  fHasExtraRequest{false};
+         bool                  fHasExtraRequest = false;
+         bool                  fLegacyFormat = false;
 
          // from addon
          void OnThreadAssigned() override;
@@ -90,7 +91,7 @@ namespace mbs {
          ServerOutputAddon(int fd, int kind, dabc::EventsIteratorRef& iter, uint32_t subid);
          virtual ~ServerOutputAddon();
 
-         void FillServInfo(int32_t maxbytes, bool isnewformat);
+         void FillServInfo(int32_t maxbytes, bool legacy);
          void SetServerKind(int kind) { fKind = kind; }
 
          // code from the DataOutput

--- a/plugins/mbs/mbs/ServerTransport.h
+++ b/plugins/mbs/mbs/ServerTransport.h
@@ -116,7 +116,8 @@ namespace mbs {
          bool fDeliverAll{false};  ///< if true, server will try deliver all events when clients are there (default for transport)
          std::string fIterKind;    ///< iterator kind when non-mbs events should be delivered to clients
          uint32_t fSubevId{0};     ///< subevent id when non-MBS events are used
-         unsigned fBufSize{0};    ///< maximal buffer size
+         unsigned fBufSize{0};     ///< maximal buffer size
+         bool fLegacy = false;     ///< attempt to emulate native MBS transport, which sends complete buffer
 
          bool StartTransport() override;
          bool StopTransport() override;

--- a/plugins/mbs/src/ServerTransport.cxx
+++ b/plugins/mbs/src/ServerTransport.cxx
@@ -353,12 +353,21 @@ mbs::ServerTransport::ServerTransport(dabc::Command cmd, const dabc::PortRef& ou
    if (url.HasOption("bufsize"))
       fBufSize = (unsigned) url.GetOptionInt("bufsize", 0) * 0x100000;
 
+   if (url.HasOption("legacy"))
+      fLegacy = true;
+
    if (fBufSize == 0) {
-      fBufSize = 0x400000;
       dabc::MemoryPoolRef pool = dabc::mgr.FindPool(dabc::xmlWorkPool);
-      auto maxbuf = pool.GetMaxBufSize() * 3 / 2;
-      if (maxbuf > fBufSize)
-         fBufSize = maxbuf;
+      auto maxbuf = pool.GetMaxBufSize();
+
+      if (fLegacy)
+         fBufSize = maxbuf + sizeof(mbs::BufferHeader);
+      else {
+         fBufSize = 0x400000;
+         maxbuf *= 1.5;
+         if (maxbuf > fBufSize)
+            fBufSize = maxbuf;
+      }
    }
 
    // by default transport server is blocking and stream is unblocking
@@ -369,10 +378,13 @@ mbs::ServerTransport::ServerTransport(dabc::Command cmd, const dabc::PortRef& ou
 
    fDeliverAll = (fKind == mbs::TransportServer);
 
-   if (url.HasOption("nonblock")) fBlocking = false; else
-   if (url.HasOption("blocking")) fBlocking = true;
+   if (url.HasOption("nonblock"))
+      fBlocking = false;
+   else if (url.HasOption("blocking"))
+      fBlocking = true;
 
-   if (url.HasOption("deliverall")) fDeliverAll = true;
+   if (url.HasOption("deliverall"))
+      fDeliverAll = true;
 
    DOUT0("Create MBS server fd:%d kind:%s port:%d limit:%d blocking:%s deliverall:%s bufsize 0x%04x",
          connaddon->Socket(), mbs::ServerKindToStr(fKind), fPortNum, fClientsLimit, DBOOL(fBlocking), DBOOL(fDeliverAll), fBufSize);

--- a/plugins/mbs/src/ServerTransport.cxx
+++ b/plugins/mbs/src/ServerTransport.cxx
@@ -296,7 +296,9 @@ unsigned mbs::ServerOutputAddon::Write_Buffer(dabc::Buffer& buf)
 
    if (fIter.null() || is_mbs_buffer) {
       fState = oSendingBuffer;
-      StartNetSend(&fHeader, sizeof(fHeader), buf);
+      dabc::BufferSize_t datasize = !fLegacyFormat ? 0 : fServInfo.iMaxBytes - sizeof(fHeader);
+      // when send legacy format - complete buffer size has to be send
+      StartNetSend(&fHeader, sizeof(fHeader), buf, datasize);
    } else {
       fState = oSendingEvents;
       StartSend(&fHeader, sizeof(fHeader));

--- a/plugins/mbs/src/ServerTransport.cxx
+++ b/plugins/mbs/src/ServerTransport.cxx
@@ -42,14 +42,16 @@ mbs::ServerOutputAddon::~ServerOutputAddon()
    DOUT3("Destroy ServerOutputAddon %p", this);
 }
 
-void mbs::ServerOutputAddon::FillServInfo(int32_t maxbytes, bool isnewformat)
+void mbs::ServerOutputAddon::FillServInfo(int32_t maxbytes, bool legacy)
 {
    memset(&fServInfo, 0, sizeof(fServInfo));
 
-   fServInfo.iEndian = 1;              // byte order. Set to 1 by sender
-   fServInfo.iMaxBytes = maxbytes;     // maximum buffer size
-   fServInfo.iBuffers = 1;             // buffers per stream
-   fServInfo.iStreams = isnewformat ? 0 : 1;     // number of streams (could be set to -1 to indicate variable length buffers, size l_free[1])
+   fServInfo.iEndian = 1;               // byte order. Set to 1 by sender
+   fServInfo.iMaxBytes = maxbytes;      // maximum buffer size
+   fServInfo.iBuffers = 1;              // buffers per stream
+   fServInfo.iStreams = legacy ? 1 : 0; // number of streams (could be set to -1 to indicate variable length buffers, size l_free[1])
+
+   fLegacyFormat = legacy;
 }
 
 void mbs::ServerOutputAddon::OnThreadAssigned()
@@ -447,9 +449,10 @@ int mbs::ServerTransport::ExecuteCommand(dabc::Command cmd)
 
       auto addon = new ServerOutputAddon(fd, fKind, iter, fSubevId);
 
-      addon->FillServInfo(fBufSize, true);
+      addon->FillServInfo(fBufSize, fLegacy);
 
-      if (portindx<0) portindx = CreateOutput(dabc::format("Slave%u",NumOutputs()), fSlaveQueueLength);
+      if (portindx < 0)
+         portindx = CreateOutput(dabc::format("Slave%u",NumOutputs()), fSlaveQueueLength);
 
       dabc::TransportRef tr = new dabc::OutputTransport(dabc::Command(), FindPort(OutputName(portindx)), addon, false);
 

--- a/plugins/mbs/src/ServerTransport.cxx
+++ b/plugins/mbs/src/ServerTransport.cxx
@@ -259,7 +259,8 @@ unsigned mbs::ServerOutputAddon::Write_Buffer(dabc::Buffer& buf)
          while (iter->NextEvent())
             events++;
          iter->Close();
-         if (events == 0) return dabc::do_Skip;
+         if (events == 0)
+            return dabc::do_Skip;
       } else {
          sendsize = 0;
          unsigned rawsize = 0;
@@ -274,7 +275,8 @@ unsigned mbs::ServerOutputAddon::Write_Buffer(dabc::Buffer& buf)
          }
          iter->Close();
 
-         if (rawsize == 0) return dabc::do_Skip;
+         if (rawsize == 0)
+            return dabc::do_Skip;
 
          iter->Assign(buf);
          iter->NextEvent(); // shift to first event
@@ -282,7 +284,7 @@ unsigned mbs::ServerOutputAddon::Write_Buffer(dabc::Buffer& buf)
    }
 
 
-   fHeader.Init(true);
+   fHeader.Init(!fLegacyFormat);
    fHeader.SetUsedBufferSize(sendsize);
    fHeader.SetNumEvents(events);
 


### PR DESCRIPTION
When URL parameter "legacy" provided,
first send server info with legacy information.
And then always sending full buffer length which was configured in server info.
Buffer size either derived from memory pool maxbuffer size or taken from `&bufsize=value` URL parameter where value is MB.